### PR TITLE
Feature/kairi/loading checkbox cursor

### DIFF
--- a/src/components/molecules/LabeledCheckbox.module.css
+++ b/src/components/molecules/LabeledCheckbox.module.css
@@ -7,5 +7,5 @@
 }
 
 .disabled .pointable {
-  cursor: default;
+  cursor: wait;
 }

--- a/src/components/molecules/LabeledCheckbox.tsx
+++ b/src/components/molecules/LabeledCheckbox.tsx
@@ -7,12 +7,13 @@ type Props = React.ComponentPropsWithoutRef<'input'> & {
   labelText: string;
 };
 const LabeledCheckbox: React.FC<Props> = ({labelText, onChange, className, ...inputProps}) => {
-  const [checked, setChecked] = useState<boolean>(inputProps.checked === true);
+  const [checked, setChecked] = useState<boolean>(!!inputProps.checked);
+  if (!!inputProps.checked !== checked) setChecked(!!inputProps.checked);
   const changeEventHandler: React.ChangeEventHandler<HTMLInputElement> = useCallback(event => {
     onChange?.(event);
     setChecked(event.target.checked);
   }, [onChange]);
-  const disabled = inputProps.disabled === true;
+  const disabled = !!inputProps.disabled;
   return <div className={[style.LabeledCheckbox, disabled&&style.disabled, checked&&style.checked, className].join(' ')}>
     <Checkbox {...inputProps} onChange={changeEventHandler} className={style.pointable}/>
     <FormLabel htmlFor={inputProps.id} className={style.pointable}>

--- a/src/components/molecules/ToggleBlock.module.css
+++ b/src/components/molecules/ToggleBlock.module.css
@@ -3,7 +3,7 @@
 }
 
 .disabled .pointable {
-  cursor: default;
+  cursor: wait;
 }
 
 .Checkbox {

--- a/src/components/molecules/ToggleBlock.tsx
+++ b/src/components/molecules/ToggleBlock.tsx
@@ -7,12 +7,13 @@ type Props = React.ComponentPropsWithoutRef<'input'> & {
   labelText: string;
 };
 const ToggleBlock: React.FC<Props> = ({labelText, onChange, className, ...inputProps}) => {
-  const [checked, setChecked] = useState<boolean>(inputProps.checked === true);
+  const [checked, setChecked] = useState<boolean>(!!inputProps.checked);
+  if (!!inputProps.checked !== checked) setChecked(!!inputProps.checked);
   const changeEventHandler: React.ChangeEventHandler<HTMLInputElement> = useCallback(event => {
     onChange?.(event);
     setChecked(event.target.checked);
   }, [onChange]);
-  const disabled = inputProps.disabled === true;
+  const disabled = !!inputProps.disabled;
   return <div className={[style.ToggleBlock, disabled&&style.disabled, checked&&style.checked, className].join(' ')}>
     <Checkbox {...inputProps} onChange={changeEventHandler} className={[style.Checkbox, style.pointable].join(' ')}/>
     <FormLabel htmlFor={inputProps.id} className={[style.FormLabel, style.pointable].join(' ')}>


### PR DESCRIPTION
- [ロード中チェックボックスではカーソルをwaitにする](https://github.com/kairi003/pref-pop-graph/commit/a06047c5cb63f408d5045bf9ef67aa0b0cc91d45)
- [[fix] チェックstateが正常に更新されないバグを修正](https://github.com/kairi003/pref-pop-graph/commit/f017806c0495f9b4a501b387bd997c685e8eafce)