### PR TITLE
[update] Header, Footerをgridにしてスマホでは中央寄せに

### DIFF
--- a/src/components/organisms/Header.module.css
+++ b/src/components/organisms/Header.module.css
@@ -1,3 +1,3 @@
-.Footer {
+.Header {
   display: grid;
 }

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import HeaderTitle from 'components/atoms/HeaderTitle';
 import HeaderDescription from 'components/atoms/HeaderDescription';
+import style from './Header.module.css'
 
 export type HeaderProps = {title: string, description?: string, className?: string, style?: React.CSSProperties};
 const Header: React.FC<HeaderProps> = ({title, description, ...props}) => {
-  const className = [props.className].join(' ');
+  const className = [props.className, style.Header].join(' ');
   return <header className={className}>
     <HeaderTitle title={title}/>
     {description && <HeaderDescription text={description}/>}

--- a/src/components/templates/SPTemplate.module.css
+++ b/src/components/templates/SPTemplate.module.css
@@ -13,3 +13,7 @@
   display: grid;
   row-gap: 1rem;
 }
+
+.Header, .Footer {
+  justify-items: center;
+}

--- a/src/components/templates/SPTemplate.tsx
+++ b/src/components/templates/SPTemplate.tsx
@@ -13,12 +13,12 @@ type Props = PrefecturePopulationReturnType & {
 
 export const SPTemplate: React.FC<Props> = ({prefPops, prefCheckProps, headerProps, footerProps}) => {
   return <div className={style.SPTemplate}>
-  <Header {...headerProps}/>
+  <Header {...headerProps} className={style.Header}/>
   <main className={style.main}>
     <PrefBlockList {...prefCheckProps} />
     <PopulationChart prefPops={prefPops} />
   </main>
-  <Footer {...footerProps}/>
+  <Footer {...footerProps} className={style.Footer}/>
 </div>;
 }
 


### PR DESCRIPTION
SPTemplateでのみ`justify-items: center`を適用

Close #13 